### PR TITLE
Show error banner when program fetching fails

### DIFF
--- a/src/console/ConsolePage.jsx
+++ b/src/console/ConsolePage.jsx
@@ -81,6 +81,22 @@ export class ConsolePage extends React.Component {
       <div className="container half-width-element py-5 align-items-start">
         <h1>Program Console</h1>
         <StatusAlert
+          alertType="danger"
+          dismissible={false}
+          dialog={(
+            <div>
+              <p>
+                An error was encountered while loading your program list: <em>{`${this.props.loadingError}`}</em>
+              </p>
+              <p>
+                Please try waiting a moment and then refreshing the page.
+                If the issue persists, please reach out to <a href="mailto:partner-support@edx.org">partner-support@edx.org</a>.
+              </p>
+            </div>
+          )}
+          open={!!this.props.loadingError}
+        />
+        <StatusAlert
           dismissible={false}
           dialog={(
             <p>
@@ -88,7 +104,7 @@ export class ConsolePage extends React.Component {
               Please reach out to <a href="mailto:partner-support@edx.org">partner-support@edx.org</a> requesting access to the Registrar service.
             </p>
           )}
-          open={!this.props.authorized}
+          open={!this.props.authorized && !this.props.loadingError}
         />
         {this.props.data.length > 0 && this.props.data.map(program => (
           <div className="container mb-4" key={program.programKey}>
@@ -125,6 +141,7 @@ export class ConsolePage extends React.Component {
 
 ConsolePage.propTypes = {
   authorized: PropTypes.bool.isRequired,
+  loadingError: PropTypes.string,
   data: PropTypes.arrayOf(PropTypes.shape({
     programKey: PropTypes.string,
     programTitle: PropTypes.string,
@@ -137,6 +154,10 @@ ConsolePage.propTypes = {
   uploadEnrollments: PropTypes.func.isRequired,
   downloadEnrollments: PropTypes.func.isRequired,
   removeBanner: PropTypes.func.isRequired,
+};
+
+ConsolePage.defaultProps = {
+  loadingError: null,
 };
 
 export default connect(consoleSelector, {

--- a/src/console/ConsolePage.test.jsx
+++ b/src/console/ConsolePage.test.jsx
@@ -8,7 +8,7 @@ import ConnectedReportSection from '../report/reportSection';
 
 describe('ConsolePage', () => {
   it('renders with the most basic props passed to it', () => {
-    const tree = renderer.create((<ConsolePage
+    const consolePageComponent = (<ConsolePage
       authorized
       data={[]}
       downloadEnrollments={() => {}}
@@ -16,11 +16,17 @@ describe('ConsolePage', () => {
       programBanners={{}}
       uploadEnrollments={() => {}}
       removeBanner={() => {}}
-    />)).toJSON();
+    />);
+    const wrapper = mount(consolePageComponent);
+    const tree = renderer.create(consolePageComponent);
+
     expect(tree).toMatchSnapshot();
+    expect(wrapper.exists('.alert.alert-warning.show')).toEqual(false);
+    expect(wrapper.exists('.alert.alert-danger.show')).toEqual(false);
+    wrapper.unmount();
   });
 
-  it('renders an error banner if there is not an authorized user', () => {
+  it('renders a warning banner if there is not an authorized user', () => {
     const consolePageComponent = (<ConsolePage
       authorized={false}
       data={[]}
@@ -35,6 +41,27 @@ describe('ConsolePage', () => {
 
     expect(tree).toMatchSnapshot();
     expect(wrapper.exists('.alert.alert-warning.show')).toEqual(true);
+    expect(wrapper.exists('.alert.alert-danger.show')).toEqual(false);
+    wrapper.unmount();
+  });
+
+  it('renders an error banner when there was an error loading programs', () => {
+    const consolePageComponent = (<ConsolePage
+      authorized={false}
+      loadingError="Request failed with HTTP 418"
+      data={[]}
+      downloadEnrollments={() => {}}
+      fetchPrograms={() => {}}
+      programBanners={{}}
+      uploadEnrollments={() => {}}
+      removeBanner={() => {}}
+    />);
+    const wrapper = mount(consolePageComponent);
+    const tree = renderer.create(consolePageComponent);
+
+    expect(tree).toMatchSnapshot();
+    expect(wrapper.exists('.alert.alert-warning.show')).toEqual(false);
+    expect(wrapper.exists('.alert.alert-danger.show')).toEqual(true);
     wrapper.unmount();
   });
 
@@ -71,8 +98,8 @@ describe('ConsolePage', () => {
       expect(wrapper.find(Collapsible).at(idx).prop('defaultOpen')).toEqual(true);
     });
 
-    expect(wrapper.exists('.alert-danger')).toEqual(false);
-    expect(wrapper.exists('.alert-info')).toEqual(false);
+    expect(wrapper.exists('.alert-danger.show')).toEqual(false);
+    expect(wrapper.exists('.alert-info.show')).toEqual(false);
     expect(wrapper.exists('.alert-warning.show')).toEqual(false);
 
     wrapper.unmount();
@@ -193,8 +220,8 @@ describe('ConsolePage', () => {
     const tree = renderer.create(consolePageComponent).toJSON();
 
     expect(tree).toMatchSnapshot();
-    expect(wrapper.find('.alert-danger .alert-dialog').at(0).text()).toEqual('Sorry something went wrong ');
-    expect(wrapper.find('.alert-success .alert-dialog').at(0).text()).toEqual('You did it! ');
+    expect(wrapper.find('.alert-danger.show .alert-dialog').at(0).text()).toEqual('Sorry something went wrong ');
+    expect(wrapper.find('.alert-success.show .alert-dialog').at(0).text()).toEqual('You did it! ');
 
     wrapper.unmount();
   });

--- a/src/console/__snapshots__/ConsolePage.test.jsx.snap
+++ b/src/console/__snapshots__/ConsolePage.test.jsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`ConsolePage renders an error banner if there is not an authorized user 1`] = `
+exports[`ConsolePage renders a warning banner if there is not an authorized user 1`] = `
 <div
   className="container half-width-element py-5 align-items-start"
 >
@@ -8,8 +8,91 @@ exports[`ConsolePage renders an error banner if there is not an authorized user 
     Program Console
   </h1>
   <div
+    className="alert fade alert-danger"
+    hidden={true}
+    role="alert"
+  >
+    <div
+      className="alert-dialog"
+    >
+      <div>
+        <p>
+          An error was encountered while loading your program list: 
+          <em>
+            null
+          </em>
+        </p>
+        <p>
+          Please try waiting a moment and then refreshing the page. If the issue persists, please reach out to 
+          <a
+            href="mailto:partner-support@edx.org"
+          >
+            partner-support@edx.org
+          </a>
+          .
+        </p>
+      </div>
+    </div>
+  </div>
+  <div
     className="alert fade alert-warning show"
     hidden={false}
+    role="alert"
+  >
+    <div
+      className="alert-dialog"
+    >
+      <p>
+        It appears you do not have proper permissions to access this application. Please reach out to 
+        <a
+          href="mailto:partner-support@edx.org"
+        >
+          partner-support@edx.org
+        </a>
+         requesting access to the Registrar service.
+      </p>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`ConsolePage renders an error banner when there was an error loading programs 1`] = `
+<div
+  className="container half-width-element py-5 align-items-start"
+>
+  <h1>
+    Program Console
+  </h1>
+  <div
+    className="alert fade alert-danger show"
+    hidden={false}
+    role="alert"
+  >
+    <div
+      className="alert-dialog"
+    >
+      <div>
+        <p>
+          An error was encountered while loading your program list: 
+          <em>
+            Request failed with HTTP 418
+          </em>
+        </p>
+        <p>
+          Please try waiting a moment and then refreshing the page. If the issue persists, please reach out to 
+          <a
+            href="mailto:partner-support@edx.org"
+          >
+            partner-support@edx.org
+          </a>
+          .
+        </p>
+      </div>
+    </div>
+  </div>
+  <div
+    className="alert fade alert-warning"
+    hidden={true}
     role="alert"
   >
     <div
@@ -36,6 +119,33 @@ exports[`ConsolePage renders program banners when they are included 1`] = `
   <h1>
     Program Console
   </h1>
+  <div
+    className="alert fade alert-danger"
+    hidden={true}
+    role="alert"
+  >
+    <div
+      className="alert-dialog"
+    >
+      <div>
+        <p>
+          An error was encountered while loading your program list: 
+          <em>
+            null
+          </em>
+        </p>
+        <p>
+          Please try waiting a moment and then refreshing the page. If the issue persists, please reach out to 
+          <a
+            href="mailto:partner-support@edx.org"
+          >
+            partner-support@edx.org
+          </a>
+          .
+        </p>
+      </div>
+    </div>
+  </div>
   <div
     className="alert fade alert-warning"
     hidden={true}
@@ -376,6 +486,33 @@ exports[`ConsolePage renders programs when there is data passed in 1`] = `
     Program Console
   </h1>
   <div
+    className="alert fade alert-danger"
+    hidden={true}
+    role="alert"
+  >
+    <div
+      className="alert-dialog"
+    >
+      <div>
+        <p>
+          An error was encountered while loading your program list: 
+          <em>
+            null
+          </em>
+        </p>
+        <p>
+          Please try waiting a moment and then refreshing the page. If the issue persists, please reach out to 
+          <a
+            href="mailto:partner-support@edx.org"
+          >
+            partner-support@edx.org
+          </a>
+          .
+        </p>
+      </div>
+    </div>
+  </div>
+  <div
     className="alert fade alert-warning"
     hidden={true}
     role="alert"
@@ -656,6 +793,33 @@ exports[`ConsolePage renders with the most basic props passed to it 1`] = `
   <h1>
     Program Console
   </h1>
+  <div
+    className="alert fade alert-danger"
+    hidden={true}
+    role="alert"
+  >
+    <div
+      className="alert-dialog"
+    >
+      <div>
+        <p>
+          An error was encountered while loading your program list: 
+          <em>
+            null
+          </em>
+        </p>
+        <p>
+          Please try waiting a moment and then refreshing the page. If the issue persists, please reach out to 
+          <a
+            href="mailto:partner-support@edx.org"
+          >
+            partner-support@edx.org
+          </a>
+          .
+        </p>
+      </div>
+    </div>
+  </div>
   <div
     className="alert fade alert-warning"
     hidden={true}


### PR DESCRIPTION
## Overview
```
Show error banner when program fetching fails

Before this, the users would simply see an
"access denied"-like message when the API request
to fetch program metadata from Registrar failed.

We want to distinguish between actual "access
denied" instances and "something unexpected went
wrong" messages.
```
Related to [PROD-1682](https://openedx.atlassian.net/browse/PROD-1682)
@edx/masters-devs 

## Program listing returns http status >=400, before:
![program-console-error_before](https://user-images.githubusercontent.com/3628148/84213187-fe31ab00-aa8d-11ea-91f7-3889553f3907.png)

Note that this screen is still shown when the user actually doesn't have access to any programs (i.e., the program listing endpoint returns HTTP 200 with an empty list).

## Program listing returns http status >=400, after:
![program-console-error_after](https://user-images.githubusercontent.com/3628148/84213188-feca4180-aa8d-11ea-8233-54243dba6e57.png)

The italicized message is taken from the errored response as provided by the HTTP client (it's not exposing anything that wasn't already available to the client via the browser debug tools).

