### PR TITLE
update openedx.yaml to use current best practices

### DIFF
--- a/openedx.yaml
+++ b/openedx.yaml
@@ -1,10 +1,6 @@
 # This file describes this Open edX repo, as described in OEP-2:
 # https://open-edx-proposals.readthedocs.io/en/latest/oep-0002-bp-repo-metadata.html#specification
 
-nick: proman
 oeps:
   oep-11: true  # Front-end tech standards
   oep-16: true  # Bootstrap 4
-owner: schenedx
-supporting_teams:
-  - masters-devs


### PR DESCRIPTION
Remove deprecated fields from openedx.yaml, per the [OEP](https://open-edx-proposals.readthedocs.io/en/latest/oep-0002-bp-repo-metadata.html). The ownership document should the single source of truth for ownership information.

