### PR TITLE
fix: Update pull_translations to include additional sources and imports

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,12 @@ detect_changed_source_translations:
 	# Checking for changed translations...
 	git diff --exit-code $(i18n)
 
-# Experimental: OEP-58 Pulls translations using atlas
+# Variables for additional translation sources and imports (define in edx-internal if needed)
+ATLAS_EXTRA_SOURCES ?=
+ATLAS_EXTRA_INTL_IMPORTS ?=
+ATLAS_OPTIONS ?=
+
+# OEP-58: Pulls translations using atlas
 pull_translations:
 	rm -rf src/i18n/messages
 	mkdir src/i18n/messages
@@ -36,9 +41,11 @@ pull_translations:
                translations/frontend-component-footer/src/i18n/messages:frontend-component-footer \
                translations/frontend-component-header/src/i18n/messages:frontend-component-header \
                translations/paragon/src/i18n/messages:paragon \
-               translations/frontend-app-account/src/i18n/messages:frontend-app-program-manager
+			   translations/frontend-app-account/src/i18n/messages:frontend-app-program-manager \
+               translations/frontend-app-program-console/src/i18n/messages:frontend-app-program-console \
+               $(ATLAS_EXTRA_SOURCES)
 
-	$(intl_imports) frontend-platform frontend-component-header frontend-component-footer paragon frontend-app-program-manager
+	$(intl_imports) frontend-platform frontend-component-header frontend-component-footer paragon frontend-app-program-manager frontend-app-program-console $(ATLAS_EXTRA_INTL_IMPORTS)
 
 
 validate-no-uncommitted-package-lock-changes: ## ensure package-lock.json is committed


### PR DESCRIPTION
This pull request updates the translation pulling process in the `Makefile` to improve flexibility and support for additional sources. The main changes involve parameterizing extra translation sources and imports, and updating the list of supported frontend apps.

**Translation process improvements:**

* Added new variables (`ATLAS_EXTRA_SOURCES`, `ATLAS_EXTRA_INTL_IMPORTS`, `ATLAS_OPTIONS`) to allow specifying additional translation sources and imports externally, such as from `edx-internal`.
* Updated the list of translation sources and imports to include `frontend-app-program-console` instead of `frontend-app-program-manager`, and to append any extra sources/imports provided via the new variables.

**JIRA**
- https://2u-internal.atlassian.net/browse/COSMO2-810